### PR TITLE
Fix Docker build: use Python 3 for the exploitable GDB script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ RUN mkdir ~/pkg ~/pkgs ~/logs
 RUN apt-get update && apt-get install apt-file -y && apt-file update
 
 # install "exploitable" GDB script
-RUN apt-get update && apt-get install gdb python python-setuptools -y
-RUN wget -O- 'https://github.com/jfoote/exploitable/archive/master.tar.gz' | tar zxvf - && cd exploitable-master && python setup.py install
+RUN apt-get update && apt-get install gdb python3 python3-setuptools -y
+RUN wget -O- 'https://github.com/jfoote/exploitable/archive/master.tar.gz' | tar zxvf - && cd exploitable-master && python3 setup.py install
 
 RUN mkdir ~/fuzz-results ~/pkgs-coverage
 RUN apt-get install lcov -y


### PR DESCRIPTION
## Problem

The Docker image no longer builds on current `debian:sid`. Debian dropped the
Python 2 transitional packages, so this step fails:

```
RUN apt-get update && apt-get install gdb python python-setuptools -y
```
```
E: Package 'python' has no installation candidate
E: Unable to locate package python-setuptools
```

This is the first and only blocker — every earlier layer (AFL 2.53b, preeny,
apt-file, etc.) still builds fine.

## Fix

Minimal, two-line change: install `python3` / `python3-setuptools` and run the
`exploitable` installer with `python3`. The `exploitable` fork already supports
Python 3 — its `setup.py` only touches `distutils` inside a virtualenv and
otherwise falls back to `sysconfig`, and `python3 setup.py install` succeeds
with the setuptools currently shipped in sid.

## Verification

- `docker build -t aflize-test .` completes successfully (all 26 steps).
- `aflize hello` runs end to end inside the image and produces an
  afl-gcc + ASAN instrumented `hello_2.12.3-1_amd64.deb`, confirming the
  full `apt-get source` → `build-dep` → `dpkg-buildpackage` flow still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)